### PR TITLE
ENG-2439 Add DefaultOperatingAgreementUpdated event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+- When deploying contracts with `forge script`, always include `--verify` to
+  verify the contract on Etherscan/Basescan automatically. If verification
+  fails during deployment, follow up with `forge verify-contract` afterward.
+- The `.env` file contains RPC URLs and Etherscan API keys. It is not checked
+  into version control. `foundry.toml` references these via environment
+  variables (`${SEPOLIA_RPC_URL}`, etc.).
+- Contracts use UUPS proxy pattern via `FabricaUUPSUpgradeable`. Key roles:
+  - **Proxy admin**: authorizes upgrades (`upgradeToAndCall`)
+  - **Owner**: authorizes business logic (e.g. `addOperatingAgreementName`)
+  - These may be the same or different wallets depending on the network.
+- Deployment scripts live in `script/` and are split by operation so each can
+  be run with a different private key:
+  - `FabricaValidatorDeployImpl.s.sol` — deploy a new implementation (any wallet)
+  - `FabricaValidatorUpgrade.s.sol` — upgrade proxy to new impl (proxy admin wallet)
+  - `FabricaValidatorSetDefaultOA.s.sol` — set operating agreement name/default (owner wallet)
+- When upgrading a proxy from OZ v4 to OZ v5:
+  - Pass `abi.encodeCall(FabricaValidator.initialize, ())` as the data argument
+    to `upgradeToAndCall` so `initialize()` runs atomically during the upgrade.
+  - Do NOT pass empty data — OZ v4's `upgradeToAndCall` reverts with empty data
+    because it delegatecalls the new implementation's nonexistent fallback.
+- When committing on an issue branch, start the commit message with the issue
+  number and a space, e.g. "ENG-2428 Add validator upgrade scripts".

--- a/script/FabricaValidatorDeployImpl.s.sol
+++ b/script/FabricaValidatorDeployImpl.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {FabricaValidator} from "../src/FabricaValidator.sol";
+
+contract FabricaValidatorDeployImplScript is Script {
+    function setUp() public {}
+
+    function run(address validatorProxy) public {
+        FabricaValidator proxy = FabricaValidator(validatorProxy);
+        console.log("Proxy address:", validatorProxy);
+        console.log("Current implementation:", proxy.implementation());
+        console.log("Proxy admin:", proxy.proxyAdmin());
+        console.log("Owner:", proxy.owner());
+        vm.startBroadcast();
+        FabricaValidator newImplementation = new FabricaValidator();
+        vm.stopBroadcast();
+        console.log("New implementation deployed at:", address(newImplementation));
+    }
+}

--- a/script/FabricaValidatorSetDefaultOA.s.sol
+++ b/script/FabricaValidatorSetDefaultOA.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {FabricaValidator} from "../src/FabricaValidator.sol";
+
+contract FabricaValidatorSetDefaultOAScript is Script {
+    function setUp() public {}
+
+    function run(address validatorProxy, string calldata uri, string calldata name) public {
+        FabricaValidator validator = FabricaValidator(validatorProxy);
+        console.log("FabricaValidator proxy:", validatorProxy);
+        console.log("Current default OA:", validator.defaultOperatingAgreement());
+        string memory existingName = validator.operatingAgreementName(uri);
+        vm.startBroadcast();
+        if (bytes(existingName).length == 0) {
+            validator.addOperatingAgreementName(uri, name);
+            console.log("Added operating agreement name:", name);
+        } else {
+            console.log("Operating agreement name already set:", existingName);
+        }
+        validator.setDefaultOperatingAgreement(uri);
+        console.log("Set default operating agreement to:", uri);
+        vm.stopBroadcast();
+    }
+}

--- a/script/FabricaValidatorUpgrade.s.sol
+++ b/script/FabricaValidatorUpgrade.s.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {FabricaValidator} from "../src/FabricaValidator.sol";
+
+contract FabricaValidatorUpgradeScript is Script {
+    function setUp() public {}
+
+    function run(address validatorProxy, address newImplementation) public {
+        FabricaValidator proxy = FabricaValidator(validatorProxy);
+        console.log("Proxy address:", validatorProxy);
+        console.log("Current implementation:", proxy.implementation());
+        console.log("Upgrading to:", newImplementation);
+        vm.startBroadcast();
+        proxy.upgradeToAndCall(
+            newImplementation,
+            abi.encodeCall(FabricaValidator.initialize, ())
+        );
+        vm.stopBroadcast();
+        console.log("Proxy upgraded");
+        console.log("Verified implementation:", proxy.implementation());
+        console.log("Owner:", proxy.owner());
+    }
+}

--- a/src/FabricaValidator.sol
+++ b/src/FabricaValidator.sol
@@ -32,9 +32,11 @@ contract FabricaValidator is IFabricaValidator, Initializable, FabricaUUPSUpgrad
     string private _defaultOperatingAgreement;
 
     event OperatingAgreementNameUpdated(string uri, string name);
+    event DefaultOperatingAgreementUpdated(string uri);
 
     function setDefaultOperatingAgreement(string memory uri_) public onlyOwner {
         _defaultOperatingAgreement = uri_;
+        emit DefaultOperatingAgreementUpdated(uri_);
     }
 
     function defaultOperatingAgreement() public view returns (string memory) {


### PR DESCRIPTION
## Summary
- Add `DefaultOperatingAgreementUpdated(string uri)` event to FabricaValidator
- Emit the event from `setDefaultOperatingAgreement()`
- Supports subgraph indexing of default operating agreement changes

Part of ENG-2439: Trust Version 3.7 + Subgraph-based Operating Agreement Resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment script for contract implementations.
  * Added upgrade script with encoded initialization calls.
  * Added script for configuring operating agreements.
  * New event emitted on operating agreement updates.

* **Documentation**
  * Added comprehensive guide covering environment configuration, deployment verification, and upgrade procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->