### PR TITLE
ENG-2550 Add access control to reinitializer functions

### DIFF
--- a/src/FabricaToken.sol
+++ b/src/FabricaToken.sol
@@ -51,11 +51,11 @@ contract FabricaToken is
         __Pausable_init();
     }
 
-    function initializeV2() public reinitializer(2) {
+    function initializeV2() public onlyProxyAdmin reinitializer(2) {
         // Token-specific migration code has been removed
     }
 
-    function initializeV3() public reinitializer(3) {
+    function initializeV3() public onlyProxyAdmin reinitializer(3) {
         emit TraitMetadataURIUpdated();
     }
 

--- a/test/FabricaTokenReinitializer.t.sol
+++ b/test/FabricaTokenReinitializer.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {FabricaToken} from "../src/FabricaToken.sol";
+import {FabricaProxy} from "../src/FabricaProxy.sol";
+
+contract FabricaTokenReinitializerTest is Test {
+    FabricaToken public token;
+    address public proxyAdmin;
+    address public attacker;
+
+    function setUp() public {
+        proxyAdmin = address(0xAD);
+        attacker = address(0xBAD);
+        // Deploy implementation
+        FabricaToken impl = new FabricaToken();
+        // Deploy proxy with initialize() call and set proxyAdmin
+        bytes memory initData = abi.encodeCall(FabricaToken.initialize, ());
+        FabricaProxy proxy = new FabricaProxy(address(impl), proxyAdmin, initData);
+        token = FabricaToken(address(proxy));
+    }
+
+    function test_initializeV2_revertsForNonAdmin() public {
+        vm.prank(attacker);
+        vm.expectRevert("FabricaUUPSUpgradeable: caller is not the proxy admin");
+        token.initializeV2();
+    }
+
+    function test_initializeV3_revertsForNonAdmin() public {
+        vm.prank(attacker);
+        vm.expectRevert("FabricaUUPSUpgradeable: caller is not the proxy admin");
+        token.initializeV3();
+    }
+
+    function test_initializeV2_succeedsForProxyAdmin() public {
+        vm.prank(proxyAdmin);
+        token.initializeV2();
+    }
+
+    function test_initializeV3_succeedsForProxyAdmin() public {
+        // Must call V2 first since reinitializers must be sequential
+        vm.prank(proxyAdmin);
+        token.initializeV2();
+        vm.prank(proxyAdmin);
+        token.initializeV3();
+    }
+
+    function test_initializeV3_viaUpgradeToAndCall() public {
+        // First call V2 directly as admin
+        vm.prank(proxyAdmin);
+        token.initializeV2();
+        // Deploy a new implementation
+        FabricaToken newImpl = new FabricaToken();
+        // Upgrade and call initializeV3 atomically via upgradeToAndCall
+        vm.prank(proxyAdmin);
+        token.upgradeToAndCall(address(newImpl), abi.encodeCall(FabricaToken.initializeV3, ()));
+    }
+}


### PR DESCRIPTION
## Summary

Adds access control to `initializeV2()` and `initializeV3()` in FabricaToken to prevent front-running of reinitializer slots.

**Audit finding:** H-2 -- anyone can call these public reinitializer functions before the proxy admin, consuming the reinitializer slot. While the current bodies are near no-ops, this is architecturally dangerous for future upgrades that may add migration logic.

**Fix:** Add `onlyProxyAdmin` modifier to reinitializer functions so they can only be called by the proxy admin (directly or via `upgradeToAndCall()`), matching the pattern already used in FabricaValidator.

Addresses [ENG-2550](https://linear.app/fabrica/issue/ENG-2550)

## Manual Testing (Anvil)

Verification was performed on a local Anvil instance (chain ID 31337) using a Forge script that deploys FabricaToken behind a FabricaProxy and exercises both the unpatched and patched code paths.

### Commands

```bash
# Start Anvil
anvil --port 18550

# Phase 1: Build OLD (unpatched) code, run verification script
git checkout HEAD~1 -- src/FabricaToken.sol
forge script script/ManualTestReinitializer.s.sol \
  --rpc-url http://localhost:18550 \
  --private-key 0xac09...ff80 --broadcast -vvv

# Phase 2: Restore PATCHED code, run same script
git checkout HEAD -- src/FabricaToken.sol
forge script script/ManualTestReinitializer.s.sol \
  --rpc-url http://localhost:18550 \
  --private-key 0xac09...ff80 --broadcast -vvv
```

### Phase 1: Vulnerability reproduction (OLD unpatched code)

Deployed FabricaToken **without** `onlyProxyAdmin` behind a FabricaProxy. Proxy admin set to Anvil account 1 (`0x7099...79C8`), attacker is Anvil account 2 (`0x3C44...93BC`).

| # | Caller | Function | Result |
|---|--------|----------|--------|
| 1 | Attacker (non-admin) | `initializeV2()` | **SUCCESS** -- reinitializer slot 2 consumed |
| 2 | Attacker (non-admin) | `initializeV3()` | **SUCCESS** -- reinitializer slot 3 consumed |
| 3 | Admin | `initializeV2()` | **REVERTED** `InvalidInitialization()` -- slot already taken |

**Vulnerability confirmed:** An unprivileged attacker front-ran both reinitializer slots, permanently locking out the proxy admin from running migration logic in future upgrades.

### Phase 2: Fix verification (NEW patched code)

Deployed FabricaToken **with** `onlyProxyAdmin` modifier on both reinitializer functions.

| # | Caller | Function | Result |
|---|--------|----------|--------|
| 1 | Attacker (non-admin) | `initializeV2()` | **REVERTED** `FabricaUUPSUpgradeable: caller is not the proxy admin` |
| 2 | Attacker (non-admin) | `initializeV3()` | **REVERTED** `FabricaUUPSUpgradeable: caller is not the proxy admin` |
| 3 | Admin | `initializeV2()` | **SUCCESS** |
| 4 | Admin | `upgradeToAndCall(newImpl, initializeV3())` | **SUCCESS** -- atomic upgrade pattern works |

**Fix verified:** Non-admin callers are blocked. Admin can call reinitializers both directly and via the `upgradeToAndCall()` atomic upgrade pattern.

## Test plan

- [x] `forge test` -- 12/12 tests pass (5 new + 7 existing)
- [x] Manual Anvil verification -- vulnerability reproduced on old code, fix confirmed on new code
- [ ] CodeRabbit review
- [ ] Human review
