### PR TITLE
ENG-2551 Fix mintBatch: incorrect supply assignment and wrong TransferBatch events

### DIFF
--- a/src/FabricaToken.sol
+++ b/src/FabricaToken.sol
@@ -571,6 +571,10 @@ contract FabricaToken is
             if (properties[i].validator == address(0)) {
                 properties[i].validator = _defaultValidator;
             }
+            if (bytes(properties[i].operatingAgreement).length < 1) {
+                properties[i].operatingAgreement =
+                    IFabricaValidator(properties[i].validator).defaultOperatingAgreement();
+            }
             uint256 id = generateId(_msgSender(), sessionIds[i], properties[i].operatingAgreement);
             require(_property[id].supply == 0, "Session ID already exist, please use a different one");
             ids[i] = id;

--- a/src/FabricaToken.sol
+++ b/src/FabricaToken.sol
@@ -562,37 +562,29 @@ contract FabricaToken is
     ) internal virtual whenNotPaused returns (uint256[] memory) {
         require(recipients.length == amounts.length, "Number of recipients and amounts must match");
         require(sessionIds.length == properties.length, "sessionIds and properties length mismatch");
-        // hit stack too deep error when using more variables, so we use sessionsIds.length in multiple
-        // places instead of creating new variables
         uint256[] memory ids = new uint256[](sessionIds.length);
         for (uint256 i = 0; i < sessionIds.length; i++) {
             require(bytes(properties[i].definition).length > 0, "Definition is required");
             require(sessionIds[i] > 0, "Valid sessionId is required");
             require(properties[i].supply > 0, "Minimum supply is 1");
+            // If validator is not specified during mint, use default validator address
+            if (properties[i].validator == address(0)) {
+                properties[i].validator = _defaultValidator;
+            }
             uint256 id = generateId(_msgSender(), sessionIds[i], properties[i].operatingAgreement);
+            require(_property[id].supply == 0, "Session ID already exist, please use a different one");
+            ids[i] = id;
+            // Store property before external calls to prevent reentrancy
+            _property[id] = properties[i];
             for (uint256 j = 0; j < recipients.length; j++) {
                 address to = recipients[j];
                 require(to != address(0), "ERC1155: mint to the zero address");
                 uint256 amount = amounts[j];
                 _balances[id][to] += amount;
-                uint256[] memory amountsForRecipient = new uint256[](ids.length);
-                for (uint256 k = 0; k < ids.length; k++) {
-                    amountsForRecipient[k] = amount;
-                }
-                _doSafeBatchTransferAcceptanceCheck(_msgSender(), address(0), to, ids, amountsForRecipient, data);
-                emit TransferBatch(_msgSender(), address(0), to, ids, amountsForRecipient);
+                _doSafeTransferAcceptanceCheck(_msgSender(), address(0), to, id, amount, data);
+                emit TransferSingle(_msgSender(), address(0), to, id, amount);
             }
-            require(_property[id].supply == 0, "Session ID already exist, please use a different one");
-            // If validator is not specified during mint, use default validator address
-            if (properties[i].validator == address(0)) {
-                // set default validator address
-                properties[i].validator = _defaultValidator;
-            }
-            ids[i] = id;
-            // Update property data
-            _property[id] = properties[i];
         }
-
         return ids;
     }
 

--- a/test/FabricaToken.mintBatch.t.sol
+++ b/test/FabricaToken.mintBatch.t.sol
@@ -290,6 +290,30 @@ contract FabricaTokenMintBatchTest is Test {
         assertEq(storedValidator, address(validator));
     }
 
+    function test_mintBatch_defaultOperatingAgreement() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory sessionIds = new uint256[](1);
+        sessionIds[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        string[] memory definitions = new string[](1);
+        definitions[0] = "ipfs://def";
+        // Pass empty string as OA to trigger default
+        string[] memory oas = new string[](1);
+        oas[0] = "";
+        string[] memory configs = new string[](1);
+        configs[0] = "{}";
+        address[] memory validators = new address[](1);
+        validators[0] = address(validator);
+        uint256[] memory ids = token.mintBatch(recipients, sessionIds, amounts, definitions, oas, configs, validators);
+        (, string memory storedOA,,,) = token._property(ids[0]);
+        assertEq(storedOA, "ipfs://default-oa");
+        // Verify token ID was generated with the default OA
+        uint256 expectedId = token.generateId(address(this), 1, "ipfs://default-oa");
+        assertEq(ids[0], expectedId);
+    }
+
     function test_mintBatch_reentrancyCannotDuplicateId() public {
         // Reentrancy creates a DIFFERENT token because generateId uses
         // _msgSender() — the re-entrant caller has a different address.

--- a/test/FabricaToken.mintBatch.t.sol
+++ b/test/FabricaToken.mintBatch.t.sol
@@ -344,5 +344,9 @@ contract FabricaTokenMintBatchTest is Test {
         uint256 attackerTokenId = token.generateId(address(attacker), 1, "ipfs://oa-1");
         assertTrue(ids[0] != attackerTokenId);
         assertTrue(attacker.attacked());
+        // Verify the re-entrant mint succeeded with correct supply
+        (uint256 attackerSupply,,,,) = token._property(attackerTokenId);
+        assertEq(attackerSupply, 100);
+        assertEq(token.balanceOf(address(attacker), attackerTokenId), 100);
     }
 }

--- a/test/FabricaToken.mintBatch.t.sol
+++ b/test/FabricaToken.mintBatch.t.sol
@@ -12,22 +12,21 @@ contract MockValidator is IFabricaValidator {
     function defaultOperatingAgreement() external pure returns (string memory) {
         return "ipfs://default-oa";
     }
+
     function operatingAgreementName(string memory) external pure returns (string memory) {
         return "Test OA";
     }
+
     function uri(uint256) external pure returns (string memory) {
         return "ipfs://test-uri";
     }
 }
 
 contract ERC1155ReceiverMock is IERC1155Receiver {
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
-        external
-        pure
-        returns (bytes4)
-    {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
         return IERC1155Receiver.onERC1155Received.selector;
     }
+
     function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
         external
         pure
@@ -35,6 +34,7 @@ contract ERC1155ReceiverMock is IERC1155Receiver {
     {
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
+
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return interfaceId == type(IERC1155Receiver).interfaceId;
     }
@@ -44,14 +44,13 @@ contract ReentrantReceiver is IERC1155Receiver {
     FabricaToken public token;
     MockValidator public validator;
     bool public attacked;
+
     function setTarget(FabricaToken _token, MockValidator _validator) external {
         token = _token;
         validator = _validator;
     }
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
-        external
-        returns (bytes4)
-    {
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
         if (!attacked) {
             attacked = true;
             // Attempt reentrancy: try to mint with same sessionId
@@ -73,6 +72,7 @@ contract ReentrantReceiver is IERC1155Receiver {
         }
         return IERC1155Receiver.onERC1155Received.selector;
     }
+
     function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
         external
         pure
@@ -80,6 +80,7 @@ contract ReentrantReceiver is IERC1155Receiver {
     {
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
+
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return interfaceId == type(IERC1155Receiver).interfaceId;
     }
@@ -284,9 +285,7 @@ contract FabricaTokenMintBatchTest is Test {
         // Pass zero address as validator to trigger default
         address[] memory validators = new address[](1);
         validators[0] = address(0);
-        uint256[] memory ids = token.mintBatch(
-            recipients, sessionIds, amounts, definitions, oas, configs, validators
-        );
+        uint256[] memory ids = token.mintBatch(recipients, sessionIds, amounts, definitions, oas, configs, validators);
         (,,,, address storedValidator) = token._property(ids[0]);
         assertEq(storedValidator, address(validator));
     }
@@ -311,9 +310,7 @@ contract FabricaTokenMintBatchTest is Test {
         configs[0] = "{}";
         address[] memory validators = new address[](1);
         validators[0] = address(validator);
-        uint256[] memory ids = token.mintBatch(
-            recipients, sessionIds, amounts, definitions, oas, configs, validators
-        );
+        uint256[] memory ids = token.mintBatch(recipients, sessionIds, amounts, definitions, oas, configs, validators);
         // Outer mint succeeded with correct supply
         assertEq(ids.length, 1);
         (uint256 supply,,,,) = token._property(ids[0]);

--- a/test/FabricaToken.mintBatch.t.sol
+++ b/test/FabricaToken.mintBatch.t.sol
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {FabricaToken} from "../src/FabricaToken.sol";
+import {IFabricaValidator} from "../src/IFabricaValidator.sol";
+import {IERC1155} from "../lib/openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol";
+import {IERC1155Receiver} from "../lib/openzeppelin-contracts/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {ERC1967Proxy} from "../lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract MockValidator is IFabricaValidator {
+    function defaultOperatingAgreement() external pure returns (string memory) {
+        return "ipfs://default-oa";
+    }
+    function operatingAgreementName(string memory) external pure returns (string memory) {
+        return "Test OA";
+    }
+    function uri(uint256) external pure returns (string memory) {
+        return "ipfs://test-uri";
+    }
+}
+
+contract ERC1155ReceiverMock is IERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId;
+    }
+}
+
+contract ReentrantReceiver is IERC1155Receiver {
+    FabricaToken public token;
+    MockValidator public validator;
+    bool public attacked;
+    function setTarget(FabricaToken _token, MockValidator _validator) external {
+        token = _token;
+        validator = _validator;
+    }
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
+        external
+        returns (bytes4)
+    {
+        if (!attacked) {
+            attacked = true;
+            // Attempt reentrancy: try to mint with same sessionId
+            address[] memory recipients = new address[](1);
+            recipients[0] = address(this);
+            uint256[] memory sessionIds = new uint256[](1);
+            sessionIds[0] = 1;
+            uint256[] memory amounts = new uint256[](1);
+            amounts[0] = 100;
+            string[] memory defs = new string[](1);
+            defs[0] = "ipfs://def-1";
+            string[] memory oas = new string[](1);
+            oas[0] = "ipfs://oa-1";
+            string[] memory configs = new string[](1);
+            configs[0] = "{}";
+            address[] memory validators = new address[](1);
+            validators[0] = address(validator);
+            token.mintBatch(recipients, sessionIds, amounts, defs, oas, configs, validators);
+        }
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId;
+    }
+}
+
+contract FabricaTokenMintBatchTest is Test {
+    FabricaToken public token;
+    MockValidator public validator;
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+
+    function setUp() public {
+        FabricaToken impl = new FabricaToken();
+        bytes memory initData = abi.encodeCall(FabricaToken.initialize, ());
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        token = FabricaToken(address(proxy));
+        validator = new MockValidator();
+        token.setDefaultValidator(address(validator));
+    }
+
+    function _mintBatchSingle(address recipient, uint256 sessionId, uint256 amount)
+        internal
+        returns (uint256[] memory)
+    {
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient;
+        uint256[] memory sessionIds = new uint256[](1);
+        sessionIds[0] = sessionId;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+        string[] memory definitions = new string[](1);
+        definitions[0] = "ipfs://def-1";
+        string[] memory oas = new string[](1);
+        oas[0] = "ipfs://oa-1";
+        string[] memory configs = new string[](1);
+        configs[0] = "{}";
+        address[] memory validators = new address[](1);
+        validators[0] = address(validator);
+        return token.mintBatch(recipients, sessionIds, amounts, definitions, oas, configs, validators);
+    }
+
+    function _mintBatchTwo(
+        address[] memory recipients,
+        uint256[] memory amounts,
+        uint256 sessionId1,
+        uint256 sessionId2
+    ) internal returns (uint256[] memory) {
+        uint256[] memory sessionIds = new uint256[](2);
+        sessionIds[0] = sessionId1;
+        sessionIds[1] = sessionId2;
+        string[] memory definitions = new string[](2);
+        definitions[0] = "ipfs://def-1";
+        definitions[1] = "ipfs://def-2";
+        string[] memory oas = new string[](2);
+        oas[0] = "ipfs://oa-1";
+        oas[1] = "ipfs://oa-2";
+        string[] memory configs = new string[](2);
+        configs[0] = "{}";
+        configs[1] = "{}";
+        address[] memory validators = new address[](2);
+        validators[0] = address(validator);
+        validators[1] = address(validator);
+        return token.mintBatch(recipients, sessionIds, amounts, definitions, oas, configs, validators);
+    }
+
+    function test_mintBatch_singleToken_correctSupply() public {
+        uint256[] memory ids = _mintBatchSingle(alice, 1, 1000);
+        assertEq(ids.length, 1);
+        (uint256 supply,,,,) = token._property(ids[0]);
+        assertEq(supply, 1000);
+        assertEq(token.balanceOf(alice, ids[0]), 1000);
+    }
+
+    function test_mintBatch_twoTokens_correctSupplyPerToken() public {
+        address[] memory recipients = new address[](2);
+        recipients[0] = alice;
+        recipients[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 300;
+        amounts[1] = 700;
+        uint256[] memory ids = _mintBatchTwo(recipients, amounts, 1, 2);
+        assertEq(ids.length, 2);
+        // Each token should have supply = 300 + 700 = 1000
+        (uint256 supply0,,,,) = token._property(ids[0]);
+        (uint256 supply1,,,,) = token._property(ids[1]);
+        assertEq(supply0, 1000);
+        assertEq(supply1, 1000);
+        // Each recipient gets their amount for each token
+        assertEq(token.balanceOf(alice, ids[0]), 300);
+        assertEq(token.balanceOf(bob, ids[0]), 700);
+        assertEq(token.balanceOf(alice, ids[1]), 300);
+        assertEq(token.balanceOf(bob, ids[1]), 700);
+    }
+
+    function test_mintBatch_emitsCorrectTransferSingleEvents() public {
+        address[] memory recipients = new address[](2);
+        recipients[0] = alice;
+        recipients[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100;
+        amounts[1] = 200;
+        // Pre-compute the expected token IDs
+        uint256 expectedId0 = token.generateId(address(this), 10, "ipfs://oa-1");
+        uint256 expectedId1 = token.generateId(address(this), 20, "ipfs://oa-2");
+        // Expect TransferSingle for token 0, alice
+        vm.expectEmit(true, true, true, true);
+        emit IERC1155.TransferSingle(address(this), address(0), alice, expectedId0, 100);
+        // Expect TransferSingle for token 0, bob
+        vm.expectEmit(true, true, true, true);
+        emit IERC1155.TransferSingle(address(this), address(0), bob, expectedId0, 200);
+        // Expect TransferSingle for token 1, alice
+        vm.expectEmit(true, true, true, true);
+        emit IERC1155.TransferSingle(address(this), address(0), alice, expectedId1, 100);
+        // Expect TransferSingle for token 1, bob
+        vm.expectEmit(true, true, true, true);
+        emit IERC1155.TransferSingle(address(this), address(0), bob, expectedId1, 200);
+        _mintBatchTwo(recipients, amounts, 10, 20);
+    }
+
+    function test_mintBatch_returnsCorrectIds() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 500;
+        uint256 expectedId0 = token.generateId(address(this), 10, "ipfs://oa-1");
+        uint256 expectedId1 = token.generateId(address(this), 20, "ipfs://oa-2");
+        uint256[] memory ids = _mintBatchTwo(recipients, amounts, 10, 20);
+        assertEq(ids[0], expectedId0);
+        assertEq(ids[1], expectedId1);
+    }
+
+    function test_mintBatch_contractRecipient_acceptanceCheck() public {
+        ERC1155ReceiverMock receiver = new ERC1155ReceiverMock();
+        address[] memory recipients = new address[](1);
+        recipients[0] = address(receiver);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        uint256[] memory ids = _mintBatchTwo(recipients, amounts, 1, 2);
+        assertEq(token.balanceOf(address(receiver), ids[0]), 100);
+        assertEq(token.balanceOf(address(receiver), ids[1]), 100);
+    }
+
+    function test_mintBatch_revertsOnDuplicateSessionId() public {
+        // First mint succeeds
+        _mintBatchSingle(alice, 1, 100);
+        // Second mint with same session should revert
+        vm.expectRevert("Session ID already exist, please use a different one");
+        _mintBatchSingle(alice, 1, 100);
+    }
+
+    function test_mintBatch_revertsOnZeroAddress() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = address(0);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        uint256[] memory sessionIds = new uint256[](1);
+        sessionIds[0] = 1;
+        string[] memory definitions = new string[](1);
+        definitions[0] = "ipfs://def";
+        string[] memory oas = new string[](1);
+        oas[0] = "ipfs://oa";
+        string[] memory configs = new string[](1);
+        configs[0] = "{}";
+        address[] memory validators = new address[](1);
+        validators[0] = address(validator);
+        vm.expectRevert("ERC1155: mint to the zero address");
+        token.mintBatch(recipients, sessionIds, amounts, definitions, oas, configs, validators);
+    }
+
+    function test_mintBatch_revertsOnZeroAmount() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory sessionIds = new uint256[](1);
+        sessionIds[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 0;
+        string[] memory definitions = new string[](1);
+        definitions[0] = "ipfs://def";
+        string[] memory oas = new string[](1);
+        oas[0] = "ipfs://oa";
+        string[] memory configs = new string[](1);
+        configs[0] = "{}";
+        address[] memory validators = new address[](1);
+        validators[0] = address(validator);
+        vm.expectRevert("Each amount must be greater than zero");
+        token.mintBatch(recipients, sessionIds, amounts, definitions, oas, configs, validators);
+    }
+
+    function test_mintBatch_defaultValidator() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory sessionIds = new uint256[](1);
+        sessionIds[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        string[] memory definitions = new string[](1);
+        definitions[0] = "ipfs://def";
+        string[] memory oas = new string[](1);
+        oas[0] = "ipfs://oa";
+        string[] memory configs = new string[](1);
+        configs[0] = "{}";
+        // Pass zero address as validator to trigger default
+        address[] memory validators = new address[](1);
+        validators[0] = address(0);
+        uint256[] memory ids = token.mintBatch(
+            recipients, sessionIds, amounts, definitions, oas, configs, validators
+        );
+        (,,,, address storedValidator) = token._property(ids[0]);
+        assertEq(storedValidator, address(validator));
+    }
+
+    function test_mintBatch_reentrancyCannotDuplicateId() public {
+        // Reentrancy creates a DIFFERENT token because generateId uses
+        // _msgSender() — the re-entrant caller has a different address.
+        // Property stored before external calls provides defense-in-depth.
+        ReentrantReceiver attacker = new ReentrantReceiver();
+        attacker.setTarget(token, validator);
+        address[] memory recipients = new address[](1);
+        recipients[0] = address(attacker);
+        uint256[] memory sessionIds = new uint256[](1);
+        sessionIds[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        string[] memory definitions = new string[](1);
+        definitions[0] = "ipfs://def-1";
+        string[] memory oas = new string[](1);
+        oas[0] = "ipfs://oa-1";
+        string[] memory configs = new string[](1);
+        configs[0] = "{}";
+        address[] memory validators = new address[](1);
+        validators[0] = address(validator);
+        uint256[] memory ids = token.mintBatch(
+            recipients, sessionIds, amounts, definitions, oas, configs, validators
+        );
+        // Outer mint succeeded with correct supply
+        assertEq(ids.length, 1);
+        (uint256 supply,,,,) = token._property(ids[0]);
+        assertEq(supply, 100);
+        assertEq(token.balanceOf(address(attacker), ids[0]), 100);
+        // Verify the re-entrant call created a different token (different ID)
+        uint256 attackerTokenId = token.generateId(address(attacker), 1, "ipfs://oa-1");
+        assertTrue(ids[0] != attackerTokenId);
+        assertTrue(attacker.attacked());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [H-3] audit finding in mintBatch/_mintBatch:

1. **Wrong TransferBatch events**: `ids[i]` was set _after_ the inner loop that emitted events, so events contained incomplete/zero IDs and incorrect amounts arrays
2. **Incorrect event structure**: Events claimed transfers for all token IDs when only one was being minted per iteration

### Changes

- Replace `TransferBatch` with `TransferSingle` per token per recipient in `_mintBatch`, matching the existing `_mint` pattern
- Fix code ordering: set `ids[i]` and validate supply before modifying balances
- Store `_property[id]` before external calls (defense-in-depth for checks-effects-interactions)
- Use `_doSafeTransferAcceptanceCheck` (single) instead of `_doSafeBatchTransferAcceptanceCheck`
- Add comprehensive Foundry tests for mintBatch events and supply

## Manual Anvil Testing

Deployed to local Anvil (`anvil --port 8555`) using a Forge deploy script, then verified with `cast`.

### Deploy

```
forge script script/DeployForAnvil.s.sol --rpc-url http://127.0.0.1:8555 --broadcast
VALIDATOR=0x5FbDB2315678afecb367f032d93F642f64180aa3
TOKEN_PROXY=0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
```

### Test 1: mintBatch 2 tokens x 2 recipients — events

```
cast send $TOKEN "mintBatch(address[],uint256[],uint256[],string[],string[],string[],address[])" \
  "[$ALICE,$BOB]" "[100,200]" "[300,700]" \
  "[ipfs://def-A,ipfs://def-B]" "[ipfs://oa-1,ipfs://oa-2]" "[{},{}]" \
  "[$VALIDATOR,$VALIDATOR]"
```

Parsed logs from `cast receipt --json`:

```
Event 0: TransferSingle
  operator: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
  from:     0x0000000000000000000000000000000000000000
  to:       0x00000000000000000000000000000000000a11ce  (Alice)
  id:       18315379509438593170
  amount:   300

Event 1: TransferSingle
  operator: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
  from:     0x0000000000000000000000000000000000000000
  to:       0x0000000000000000000000000000000000000b0b  (Bob)
  id:       18315379509438593170
  amount:   700

Event 2: TransferSingle
  operator: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
  from:     0x0000000000000000000000000000000000000000
  to:       0x00000000000000000000000000000000000a11ce  (Alice)
  id:       10707562386028958175
  amount:   300

Event 3: TransferSingle
  operator: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
  from:     0x0000000000000000000000000000000000000000
  to:       0x0000000000000000000000000000000000000b0b  (Bob)
  id:       10707562386028958175
  amount:   700
```

All 4 events have correct non-zero IDs. Token 0 ID=18315379509438593170, Token 1 ID=10707562386028958175. PASS.

### Test 2: Supply per token

```
cast call $TOKEN "_property(uint256)(uint256,string,string,string,address)" 18315379509438593170
=> 1000  "ipfs://oa-1"  "ipfs://def-A"  "{}"  0x5FbDB...

cast call $TOKEN "_property(uint256)(uint256,string,string,string,address)" 10707562386028958175
=> 1000  "ipfs://oa-2"  "ipfs://def-B"  "{}"  0x5FbDB...
```

Both tokens have supply=1000 (=300+700). PASS.

### Test 3: Balances

```
cast call $TOKEN "balanceOf(address,uint256)(uint256)" $ALICE 18315379509438593170  => 300
cast call $TOKEN "balanceOf(address,uint256)(uint256)" $BOB   18315379509438593170  => 700
cast call $TOKEN "balanceOf(address,uint256)(uint256)" $ALICE 10707562386028958175  => 300
cast call $TOKEN "balanceOf(address,uint256)(uint256)" $BOB   10707562386028958175  => 700
```

PASS.

### Test 4: mint() vs mintBatch() consistency

```
cast send $TOKEN "mint(address[],uint256,uint256[],string,string,string,address)" \
  "[$ALICE]" 300 "[500]" "ipfs://def-single" "ipfs://oa-single" "{}" $VALIDATOR
=> supply: 500

cast send $TOKEN "mintBatch(address[],uint256[],uint256[],string[],string[],string[],address[])" \
  "[$ALICE]" "[301]" "[500]" "[ipfs://def-batch]" "[ipfs://oa-batch]" "[{}]" "[$VALIDATOR]"
=> supply: 500
```

Both return supply=500. PASS.

### Test 5: Duplicate session ID revert

```
cast send $TOKEN "mintBatch(...)" "[$ALICE]" "[100]" "[50]" ...
=> Error: execution reverted: Session ID already exist, please use a different one
```

PASS.

### Test 6: Reentrancy (via Foundry test)

Deployed a `ReentrantReceiver` contract that re-enters `mintBatch` during `onERC1155Received`. Result: re-entrant call creates a DIFFERENT token ID because `generateId()` includes `_msgSender()`. The outer token supply is not corrupted. Property is stored before external calls as defense-in-depth. Verified via `forge test --match-test test_mintBatch_reentrancyCannotDuplicateId -vvvv`. PASS.

## Test plan

- [x] `forge test` — 17 tests pass (10 new + 7 existing)
- [x] Anvil: TransferSingle events with correct non-zero IDs and amounts
- [x] Anvil: supply=1000 per token (300+700)
- [x] Anvil: balances correct per recipient per token
- [x] Anvil: mint() and mintBatch() supply consistent
- [x] Anvil: duplicate session ID reverts
- [x] Foundry: reentrancy creates separate token, no corruption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added guard to prevent duplicate session IDs and strengthened reentrancy protections during minting.

* **Behavior Changes**
  * Batch minting reworked into a two-pass flow: IDs are validated/created first, then per-recipient balances are updated and per-recipient batch transfer events emitted. Defaults for validator and operating agreement are now resolved automatically when omitted.

* **Tests**
  * Added comprehensive tests covering batch minting, event behavior, validator/operating-agreement defaults, error cases, and reentrancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->