### PR TITLE
docs: DEPLOYMENT.md for Paradigm/Foundry deploy flow

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,210 @@
+# Deploying contracts from this repo
+
+This repo holds all of Fabrica's Solidity contracts and their deployment
+scripts. We deploy via **Foundry's `forge script`** (Paradigm tooling), one
+script per logical operation, against the network's `--rpc-url`.
+
+For UUPS-proxy upgrades to existing FabricaToken / FabricaValidator
+deployments, see [`UPGRADE-RUNBOOK.md`](./UPGRADE-RUNBOOK.md) instead — this
+doc covers deploying new contracts.
+
+## TL;DR (for anyone vendoring something new)
+
+```bash
+# 1. From repo root, with .env populated (see "Environment setup" below):
+forge build
+
+# 2. Run the deploy script against the target network. Network names are
+#    declared in foundry.toml's [rpc_endpoints] section.
+forge script \
+  --rpc-url sepolia \
+  script/MyNewContractDeploy.s.sol \
+  --private-key $DEPLOYER_PRIVATE_KEY \
+  --broadcast \
+  --verify
+
+# 3. Record the deployed address in UPGRADE-RUNBOOK.md (or a new doc if
+#    this is a new contract family) — every consumer (soil-app,
+#    fabrica-v3-api) needs the address to reference the contract.
+```
+
+## Environment setup
+
+`.env` lives at the repo root, gitignored, sourced by `foundry.toml`. It
+must contain at least:
+
+```bash
+# RPC endpoints — one per network you intend to deploy to
+MAINNET_RPC_URL=https://mainnet.infura.io/v3/<...>
+SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/<...>
+BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+
+# Etherscan / Basescan API key for contract verification
+ETHERSCAN_API_KEY=<...>
+
+# Deployer private key. ONLY for dev/sepolia. Mainnet deploys use Safe
+# multisig + a hardware-wallet-signed transaction; never put a mainnet
+# deployer key in a .env file.
+DEPLOYER_PRIVATE_KEY=<dev-or-sepolia-key>
+```
+
+`foundry.toml`'s `[rpc_endpoints]` block declares the network names that
+`--rpc-url <name>` resolves to. Currently: `mainnet`, `sepolia`,
+`base-sepolia`. Add a new entry when introducing a new network.
+
+## Script conventions
+
+Scripts live in `script/` and are split **one per logical operation**, so
+each can be run with a different private key (per the role-separation
+pattern documented in [`CLAUDE.md`](./CLAUDE.md)):
+
+| Script suffix | Operation | Wallet that should run it |
+|---------------|-----------|---------------------------|
+| `*DeployImpl.s.sol` | Deploy a new implementation contract | Any wallet (impl is not authorized) |
+| `*Upgrade.s.sol` | Call `upgradeToAndCall` on an existing proxy | **Proxy admin** wallet |
+| `*Deploy.s.sol` (no Impl) | Deploy a fresh non-upgradeable contract | Deployer wallet of choice |
+| `*Set*.s.sol` | Set business-logic config (e.g. default validator, OA name) | **Owner** wallet |
+
+A `Script` contract has a `run()` function. If the deploy needs
+parameters (constructor args, target addresses), use `--sig` to pass them
+on the CLI:
+
+```bash
+forge script \
+  --rpc-url sepolia \
+  script/MyDeploy.s.sol \
+  --private-key $DEPLOYER_PRIVATE_KEY \
+  --broadcast \
+  --verify \
+  --sig "run(address,uint256)" \
+  0x1234... 86400
+```
+
+See the existing scripts for shape references — `FabricaValidatorUpgrade.s.sol`,
+`FabricaMarketplaceZone.s.sol`, `FabricaFeeCollector.s.sol` are good
+templates depending on what you're building.
+
+## Pre-deploy checklist
+
+Before running `--broadcast` on mainnet:
+
+- [ ] Re-run `forge test` clean
+- [ ] Mainnet-fork test exists for the new contract (`forge test --fork-url $MAINNET_RPC_URL`) and passes
+- [ ] Re-audit with latest AI models passes clean (or document why skipped — see ENG-3006 for the audit pattern)
+- [ ] Operator + counsel review on any new contract behaviors that affect user-facing flows or legal disclosures
+- [ ] `forge build` succeeds with `--sizes`; bytecode under 24 KB EIP-170 limit (or you understand why it's allowed to exceed)
+- [ ] Safe multisig configured for the actual deploy transaction (mainnet) — see "Safe multisig flow" below
+- [ ] Deployment script's `--sig` parameters reviewed line-by-line by operator
+- [ ] Etherscan API key valid (test with a sepolia deploy first if unsure)
+
+For sepolia / dev networks: skip the operator-review items but keep the
+test items.
+
+## Deploy flow (network-by-network)
+
+We default to **sepolia first, mainnet second**. For any new contract
+family, the sequence is:
+
+1. **Sepolia deploy** with the dev/sepolia deployer key. Validate end-to-end
+   (soil-app + fabrica-v3-api can read/write the contract; the relevant
+   user flow completes; events emit and the subgraph indexes them).
+2. **Soak on sepolia** for at least one cycle of real testing.
+3. **Mainnet deploy** via Safe multisig (see below) once sepolia
+   validation passes.
+4. **Post-deploy**: update all consumers (soil-app, fabrica-v3-api,
+   subgraph) to point at the new mainnet address.
+
+## Safe multisig flow (mainnet)
+
+Mainnet deployment transactions are signed by the Fabrica Safe multisig.
+The flow is:
+
+1. Build the deploy transaction calldata locally using
+   `forge script --rpc-url mainnet ... --skip-simulation` (DRY RUN — do
+   NOT use `--broadcast` here; this generates the calldata only).
+2. Inspect the calldata. It will be visible in the `broadcast/*.json`
+   output Foundry writes.
+3. Submit the transaction to the Safe Transaction Service via the Safe
+   UI or CLI, targeting the contract address `0x0` (for `CREATE`) and
+   the calldata from step 2.
+4. Collect signatures from the Safe signers (the org's signing quorum).
+5. Execute the Safe transaction. The deploy lands on-chain.
+6. **Verify the deployed bytecode** matches what `forge build` produced
+   locally. Run `forge verify-contract <deployed-address>
+   <Contract>` to push verification to Etherscan.
+
+Do NOT use `--broadcast` with a private-key flag on mainnet deploys.
+That bypasses the Safe and signs the transaction under whatever key is
+in `$DEPLOYER_PRIVATE_KEY` — which should never be a mainnet-funded key.
+
+## Post-deploy: capture the address
+
+When a deploy lands, record the new address in:
+
+1. **`UPGRADE-RUNBOOK.md`** if the contract has its own upgrade path or
+   is a proxy for an existing implementation
+2. **A new doc** if this is a brand-new contract family (e.g.
+   `DEPLOYMENT-METASTREET.md` for the forked MetaStreet pool contracts —
+   see ENG-3115 for that family's mainnet-deploy ticket)
+3. **The `.broadcast/` artifacts** — Foundry's `--broadcast` writes
+   per-network JSON files under `broadcast/<script>/<chain-id>/` that
+   record the transaction hash and deployed address. Commit these when
+   they reflect a real deploy; they're the historical record.
+4. **Soil-app + fabrica-v3-api** — every consumer that references the
+   contract address needs to be updated. A typical change touches:
+   - `fabrica-v3-api/config/{develop,staging,production}.json` —
+     per-network contract addresses
+   - `soil-app/config/networks.ts` (or equivalent) — client-side
+     address registry
+   - `fabrica-v3-subgraph` — subgraph data sources for indexed events
+
+## Verification on Etherscan / Basescan
+
+`--verify` automates Etherscan verification at deploy time. If it fails
+(network hiccup, API rate limit, missing constructor args):
+
+```bash
+forge verify-contract \
+  --chain sepolia \
+  --watch \
+  <deployed-address> \
+  src/path/to/Contract.sol:Contract
+```
+
+For contracts with constructor args, append:
+
+```bash
+  --constructor-args $(cast abi-encode "constructor(address,uint256)" 0xabc 86400)
+```
+
+`--watch` polls Etherscan until verification completes; for unattended
+deploys, omit it and check status manually.
+
+## When NOT to use `forge script`
+
+- **Existing-contract upgrades** that go through Safe + reinitializer
+  chains: follow [`UPGRADE-RUNBOOK.md`](./UPGRADE-RUNBOOK.md) — it has
+  the FabricaToken-specific OZ v4→v5 storage migration pattern.
+- **One-off Cast calls** for setting roles or paused state — use `cast send`,
+  not `forge script`.
+- **Reading deployed state** for diagnostics — `cast call`, `cast storage`.
+
+## Common gotchas
+
+- **Optimizer settings**: `foundry.toml` has `optimizer_runs = 1` (size
+  over gas). For a contract that will see many transactions over its
+  lifetime, consider raising to `optimizer_runs = 200` at deploy time
+  by passing `--optimizer-runs 200` to `forge script`. This is a
+  per-deploy decision; it doesn't change the toml file.
+- **`via_ir = false`**: don't flip this on for a specific deploy without
+  understanding the compilation-time-vs-bytecode-size tradeoff. The IR
+  pipeline is slow (10+ min builds) and produces different bytecode.
+- **Etherscan API rate limits**: free-tier keys hit limits quickly when
+  verifying many contracts in sequence. Either upgrade the key or
+  space deploys out.
+- **`--legacy` for non-EIP-1559 networks**: some sidechains require it.
+  Mainnet, sepolia, base-sepolia don't.
+- **Foundry version drift**: `foundry.lock` pins the toolchain. Always
+  `foundryup --version $(cat foundry.lock | jq -r .version)` (or
+  equivalent) before deploying. Don't deploy with a newer-than-locked
+  toolchain on mainnet.

--- a/README.md
+++ b/README.md
@@ -66,14 +66,26 @@ $ cast --help
 ```
 
 ### Deploying
+
+See **[`DEPLOYMENT.md`](./DEPLOYMENT.md)** for the full deploy flow —
+environment setup, script conventions, pre-deploy checklist, Safe
+multisig pattern for mainnet, and post-deploy address-recording
+discipline.
+
+For UUPS-proxy upgrades to existing deployments (FabricaToken,
+FabricaValidator), see **[`UPGRADE-RUNBOOK.md`](./UPGRADE-RUNBOOK.md)**.
+
+Quick reference (sepolia / dev only — mainnet uses Safe multisig per
+DEPLOYMENT.md):
+
 ```
 forge script \
-    --rpc-url [get from foundry.toml for the network] \
-    script/FabricaMarketplaceZone.s.sol # The script to deploy \
-    --private-key [actual deployment-wallet private key] \
+    --rpc-url sepolia \
+    script/FabricaMarketplaceZone.s.sol \
+    --private-key $DEPLOYER_PRIVATE_KEY \
     --broadcast \
     --verify \
-    # the following are only used if the run function has parameters \
+    # Only if the run function has parameters:
     --sig "run(address)" \
-    0x3fE51ba59dDA319d5Ac3Bf372993Ec0705dC62CB # The parameters to pass to the function
+    0x3fE51ba59dDA319d5Ac3Bf372993Ec0705dC62CB
 ```


### PR DESCRIPTION
## Summary

Operator directive 2026-05-11: ensure fabrica-v3-contracts has good documentation about deploying contracts via Paradigm scripts so that engineers vendoring new contracts here (e.g. [ENG-3101](https://linear.app/fabrica/issue/ENG-3101) MetaStreet pool fork, [ENG-3076](https://linear.app/fabrica/issue/ENG-3076) / [ENG-3113](https://linear.app/fabrica/issue/ENG-3113) follow-ups, [ENG-3115](https://linear.app/fabrica/issue/ENG-3115) mainnet bundle) have a clear single source of truth for the deploy flow.

## What's new

**\`DEPLOYMENT.md\`** at repo root, covering:

- Environment setup (\`.env\` template, \`foundry.toml\` \`[rpc_endpoints]\`)
- Script conventions — the one-script-per-operation pattern + naming suffixes already documented in CLAUDE.md, formalized into a table
- Pre-deploy checklist (tests, fork tests, audit pass, Safe multisig config, bytecode size, sig review)
- Network-by-network deploy flow (sepolia first, mainnet second)
- **Safe multisig flow for mainnet** — DRY-RUN \`forge script\` to generate calldata, submit via Safe Tx Service, collect sigs, verify deployed bytecode. Explicit "do NOT use \`--broadcast\` with a private-key flag on mainnet"
- Post-deploy address-recording discipline (UPGRADE-RUNBOOK or new doc, \`.broadcast/\` artifacts, soil-app + fabrica-v3-api + subgraph consumer updates)
- Etherscan verification fallback (\`forge verify-contract\` when \`--verify\` fails at deploy time)
- Common gotchas (\`optimizer_runs\`, \`via_ir\`, Etherscan rate limits, \`--legacy\` flag for non-EIP-1559 networks, Foundry toolchain pinning via \`foundry.lock\`)
- Pointers to UPGRADE-RUNBOOK.md for existing-proxy upgrades and to CLAUDE.md for the UUPS/role-separation conventions

**\`README.md\`** updated to point at DEPLOYMENT.md as the canonical deploy guide; the bare quick-reference snippet remains for dev/sepolia smoke deploys.

## Test plan

- [ ] Read DEPLOYMENT.md end-to-end and verify a brand-new engineer (no prior context) could follow it to deploy a contract to sepolia
- [ ] Verify the Safe-multisig flow section is consistent with how the org actually drives mainnet transactions (correcting if it diverges)
- [ ] Confirm cross-references to UPGRADE-RUNBOOK.md and CLAUDE.md are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment guide covering environment setup, deployment workflow, pre-deployment checklist, Safe multisig procedures for mainnet, and post-deployment verification steps.
  * Updated README with quick reference examples for deploying to sepolia and dev networks.
  * Added links to upgrade documentation for UUPS proxies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fabrica-land/fabrica-v3-contracts/pull/8)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->